### PR TITLE
use libbase64 macro to calculate base64 length

### DIFF
--- a/cores/esp32/base64.cpp
+++ b/cores/esp32/base64.cpp
@@ -37,8 +37,7 @@ extern "C" {
  */
 String base64::encode(uint8_t * data, size_t length)
 {
-    // base64 needs more size then the source data
-    size_t size = ((length * 1.6f) + 1);
+    size_t size = base64_encode_expected_len(length);
     char * buffer = (char *) malloc(size);
     if(buffer) {
         base64_encodestate _state;


### PR DESCRIPTION
The calculation of the base64 encoded string length is incorrect as pointed out in #827. libbase64 already provides a macro that can be used to calculate the base64 encoded string length. 